### PR TITLE
Initial Implementation

### DIFF
--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -1,0 +1,10 @@
+name: Run License Tests
+on:
+  push:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+jobs:
+  license_tests:
+    uses: neongeckocom/.github/.github/workflows/license_tests.yml@master

--- a/.github/workflows/propose_release.yml
+++ b/.github/workflows/propose_release.yml
@@ -1,0 +1,27 @@
+name: Propose Stable Release
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        type: choice
+        description: Release Type
+        options:
+          - patch
+          - minor
+          - major
+jobs:
+  update_version:
+    uses: neongeckocom/.github/.github/workflows/propose_semver_release.yml@master
+    with:
+      branch: dev
+      release_type: ${{ inputs.release_type }}
+      update_changelog: True
+  pull_changes:
+    uses: neongeckocom/.github/.github/workflows/pull_master.yml@master
+    needs: update_version
+    with:
+      pr_reviewer: neonreviewers
+      pr_assignee: ${{ github.actor }}
+      pr_draft: false
+      pr_title: ${{ needs.update_version.outputs.version }}
+      pr_body: ${{ needs.update_version.outputs.changelog }}

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,12 @@
+# This workflow will generate a release distribution and upload it to PyPI
+
+name: Publish Build and GitHub Release
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_and_publish_pypi_and_release:
+    uses: neongeckocom/.github/.github/workflows/publish_stable_release.yml@master
+    secrets: inherit

--- a/.github/workflows/publish_test_build.yml
+++ b/.github/workflows/publish_test_build.yml
@@ -1,0 +1,18 @@
+# This workflow will generate a distribution and upload it to PyPI
+
+name: Publish Alpha Build
+on:
+  push:
+    branches:
+      - dev
+    paths-ignore:
+      - 'version.py'
+
+jobs:
+  publish_alpha_release:
+    uses: neongeckocom/.github/.github/workflows/publish_alpha_release.yml@master
+    secrets: inherit
+    with:
+      version_file: "version.py"
+      publish_prerelease: true
+      update_changelog: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,41 @@
+# This workflow will run unit tests
+
+name: Unit Tests
+on:
+  push:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+jobs:
+  py_build_tests:
+    uses: neongeckocom/.github/.github/workflows/python_build_tests.yml@master
+    with:
+      python_version: "3.8"
+  unit_tests:
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install portaudio19-dev python3-pyaudio libpulse-dev ffmpeg
+          python -m pip install --upgrade pip
+          pip install cython
+          pip install . -r requirements/test_requirements.txt
+      - name: Unit Tests
+        run: |
+          pytest tests/unit_tests.py --doctest-modules --junitxml=tests/unit-test-results.xml
+      - name: Upload Unit test results
+        uses: actions/upload-artifact@v2
+        with:
+          name: unit-test-results
+          path: tests/unit-test-results.xml

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Development System
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2021 Neongecko.com Inc.
+# BSD-3 License
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -28,9 +28,18 @@ data:
 ```
 
 ### Get Metric
-Get collected metrics:
+Get processed data for a collected metric.
 ```yaml
 msg_type: neon.get_metric
+data:
+  name: Metric name/type (required)
+```
+
+### Get Raw Metric
+Get raw data for collected metrics. This will return a list of dict data for the
+requested metric (dict of metric name to list dict data if no metric requested).
+```yaml
+msg_type: neon.get_raw_metric
 data:
   name: Metric name/type (or None to get all metrics)
 ```

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ Record an arbitrary metric by emitting:
 msg_type: neon.metric
 data: 
   name: Metric name/type
-  # Add any data that will be collected as part of this metric
-context:
   timestamp: Optional timestamp metric was collected (float epoch time)
+  # Add any data that will be collected as part of this metric
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Core Monitoring Plugin
+This plugin monitors messagebus traffic to log events and metrics. This data may
+optionally be uploaded to a remote endpoint and/or saved locally for evaluation.
+
+## Configuration
+Metrics may be uploaded to an MQ endpoint for aggregation/data sharing. They may
+also be saved locally for local monitoring/evaluation.
+
+```yaml
+PHAL:
+  neon-phal-plugin-core-monitor:
+    upload_enabled: False
+    save_locally: True
+```
+
+## Messagebus API
+Messagebus events are handled to collect various metrics. There is no defined 
+set of supported metrics; any module may choose to report a metric to this plugin.
+
+### Report Metric
+Record an arbitrary metric by emitting:
+```yaml
+msg_type: neon.metric
+data: 
+  name: Metric name/type
+  # Add any data that will be collected as part of this metric
+context:
+  timestamp: Optional timestamp metric was collected (float epoch time)
+```
+

--- a/README.md
+++ b/README.md
@@ -27,3 +27,10 @@ data:
   # Add any data that will be collected as part of this metric
 ```
 
+### Get Metric
+Get collected metrics:
+```yaml
+msg_type: neon.get_metric
+data:
+  name: Metric name/type (or None to get all metrics)
+```

--- a/neon_phal_plugin_monitoring/__init__.py
+++ b/neon_phal_plugin_monitoring/__init__.py
@@ -97,10 +97,16 @@ class CoreMonitor(PHALPlugin):
         # TODO: Support backends like InfluxDb
         if self.upload_enabled:
             report_metric(name=metric_name, timestamp=timestamp, **metric_data)
+        if self.save_local:
+            # TODO: This is excessive, do this on clean exit or on a schedule
+            self._write_to_disk()
+
+    def _write_to_disk(self):
+        with open(self._save_path, 'w+') as f:
+            json.dump(self._metrics, f)
+        LOG.info(f"Wrote metrics to {self._save_path}")
 
     def shutdown(self):
         if self.save_local:
-            with open(self._save_path, 'w+') as f:
-                json.dump(self._metrics, f)
-            LOG.info(f"Wrote metrics to {self._save_path}")
+            self._write_to_disk()
         PHALPlugin.shutdown(self)

--- a/neon_phal_plugin_monitoring/__init__.py
+++ b/neon_phal_plugin_monitoring/__init__.py
@@ -58,6 +58,7 @@ class CoreMonitor(PHALPlugin):
             try:
                 with open(self._save_path) as f:
                     self._metrics = json.load(f)
+                LOG.info(f"Loaded metrics from {self._save_path}")
             except Exception as e:
                 LOG.exception(f"Failed to load {self._save_path}: {e}")
                 remove(self._save_path)
@@ -89,9 +90,11 @@ class CoreMonitor(PHALPlugin):
         except Exception as e:
             LOG.error(e)
             return
+        LOG.debug(f"Got metric: {metric_name}")
         self._metrics.setdefault(metric_name, list())
         self._metrics[metric_name].append(NeonMetric(metric_name, timestamp,
                                                      metric_data))
+        # TODO: Support backends like InfluxDb
         if self.upload_enabled:
             report_metric(name=metric_name, timestamp=timestamp, **metric_data)
 
@@ -99,4 +102,5 @@ class CoreMonitor(PHALPlugin):
         if self.save_local:
             with open(self._save_path, 'w+') as f:
                 json.dump(self._metrics, f)
+            LOG.info(f"Wrote metrics to {self._save_path}")
         PHALPlugin.shutdown(self)

--- a/neon_phal_plugin_monitoring/__init__.py
+++ b/neon_phal_plugin_monitoring/__init__.py
@@ -1,0 +1,102 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+
+from dataclasses import dataclass
+from os import remove
+from os.path import join, isfile
+from time import time
+from ovos_bus_client.message import Message
+from ovos_utils.log import LOG
+from ovos_utils.xdg_utils import xdg_state_home
+from ovos_config.meta import get_xdg_base
+from ovos_plugin_manager.phal import PHALPlugin
+from neon_utils.metrics_utils import report_metric
+
+
+@dataclass
+class NeonMetric:
+    name: str
+    timestamp: float
+    data: dict
+
+
+class CoreMonitor(PHALPlugin):
+    def __init__(self, bus=None, name="neon-phal-plugin-core-monitor",
+                 config=None):
+        PHALPlugin.__init__(self, bus, name, config)
+        self._metrics = dict()
+        self._save_path = join(xdg_state_home(), get_xdg_base(),
+                               "core_metrics.json")
+        if self.save_local and isfile(self._save_path):
+            try:
+                with open(self._save_path) as f:
+                    self._metrics = json.load(f)
+            except Exception as e:
+                LOG.exception(f"Failed to load {self._save_path}: {e}")
+                remove(self._save_path)
+        self.bus.on("neon.metric", self.on_metric)
+
+    @property
+    def save_local(self) -> bool:
+        """
+        Allow saving collected metrics locally, default True
+        """
+        return self.config.get("save_locally") is not False
+
+    @property
+    def upload_enabled(self) -> bool:
+        """
+        Allow uploading collected metrics to a remote MQ server, default False
+        """
+        return self.config.get("upload_enabled") is True
+
+    def on_metric(self, message: Message):
+        """
+        Handle a metric reported on the messagebus
+        @param message: `neon.metric` Message
+        """
+        metric_data = message.data
+        try:
+            metric_name = metric_data.pop("name")
+            timestamp = message.context.get("timestamp") or time()
+        except Exception as e:
+            LOG.error(e)
+            return
+        self._metrics.setdefault(metric_name, list())
+        self._metrics[metric_name].append(NeonMetric(metric_name, timestamp,
+                                                     metric_data))
+        if self.upload_enabled:
+            report_metric(name=metric_name, timestamp=timestamp, **metric_data)
+
+    def shutdown(self):
+        if self.save_local:
+            with open(self._save_path, 'w+') as f:
+                json.dump(self._metrics, f)
+        PHALPlugin.shutdown(self)

--- a/neon_phal_plugin_monitoring/__init__.py
+++ b/neon_phal_plugin_monitoring/__init__.py
@@ -92,7 +92,7 @@ class CoreMonitor(PHALPlugin):
         Handle a metric reported on the messagebus
         @param message: `neon.metric` Message
         """
-        metric_data = message.data
+        metric_data = dict(message.data)
         try:
             metric_name = metric_data.pop("name")
             timestamp = message.context.get("timestamp") or time()
@@ -120,7 +120,8 @@ class CoreMonitor(PHALPlugin):
         elif not request:
             resp = message.response({"error": False, **self._metrics})
         else:
-            resp = message.response({"error": False, **self._metrics[request]})
+            resp = message.response({"error": False,
+                                     request: self._metrics[request]})
         self.bus.emit(resp)
 
     def get_metric(self, message: Message):

--- a/neon_phal_plugin_monitoring/__init__.py
+++ b/neon_phal_plugin_monitoring/__init__.py
@@ -63,6 +63,7 @@ class CoreMonitor(PHALPlugin):
                 LOG.exception(f"Failed to load {self._save_path}: {e}")
                 remove(self._save_path)
         self.bus.on("neon.metric", self.on_metric)
+        self.bus.on("neon.get_metric", self.get_metric)
         self.bus.on("neon.get_raw_metric", self.get_raw_metric)
 
     @property
@@ -129,6 +130,7 @@ class CoreMonitor(PHALPlugin):
                                      "message": f"{request} not found in "
                                                 f"{self._metrics.keys()}"})
         else:
+            LOG.debug(f"Generating response for metric: {request}")
             try:
                 data = self._metrics[request]
                 flattened_lists = {}
@@ -152,6 +154,7 @@ class CoreMonitor(PHALPlugin):
                 resp = message.response({"error": True,
                                          "message": repr(e)})
         self.bus.emit(resp)
+        LOG.debug(f"Sent response: {resp.msg_type}")
 
     def _write_to_disk(self):
         with open(self._save_path, 'w+') as f:

--- a/neon_phal_plugin_monitoring/__init__.py
+++ b/neon_phal_plugin_monitoring/__init__.py
@@ -97,9 +97,6 @@ class CoreMonitor(PHALPlugin):
         # TODO: Support backends like InfluxDb
         if self.upload_enabled:
             report_metric(name=metric_name, timestamp=timestamp, **metric_data)
-        if self.save_local:
-            # TODO: This is excessive, do this on clean exit or on a schedule
-            self._write_to_disk()
 
     def _write_to_disk(self):
         with open(self._save_path, 'w+') as f:

--- a/neon_phal_plugin_monitoring/__init__.py
+++ b/neon_phal_plugin_monitoring/__init__.py
@@ -167,6 +167,10 @@ class CoreMonitor(PHALPlugin):
         LOG.debug(f"Sent response: {resp.msg_type}")
 
     def _write_to_disk(self):
+        # Truncate metrics to maximum configured length
+        for name, metric in self._metrics.items():
+            self._metrics[name] = metric[-self.max_num_history:]
+        # Write metrics to disk
         with open(self._save_path, 'w+') as f:
             json.dump(self._metrics, f)
         LOG.info(f"Wrote metrics to {self._save_path}")

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-neon-utils~=1.1
+neon-utils[network]~=1.1
 ovos-plugin-manager~=0.0.20
 ovos-bus-client~=0.0.3
 ovos-utils~=0.0.30

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,0 +1,4 @@
+neon-utils~=1.1
+ovos-plugin-manager~=0.0.20
+ovos-bus-client~=0.0.3
+ovos-utils~=0.0.30

--- a/requirements/test_requirements.txt
+++ b/requirements/test_requirements.txt
@@ -1,0 +1,2 @@
+pytest
+mock

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,71 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from setuptools import setup, find_packages
+from os import path, getenv
+
+PLUGIN_ENTRY_POINT = "neon-phal-plugin-monitoring=neon_phal_plugin_monitoring:CoreMonitor"
+BASE_PATH = path.abspath(path.dirname(__file__))
+
+
+def get_requirements(requirements_filename: str):
+    requirements_file = path.join(BASE_PATH, "requirements",
+                                  requirements_filename)
+    with open(requirements_file, 'r', encoding='utf-8') as r:
+        requirements = r.readlines()
+    requirements = [r.strip() for r in requirements if r.strip() and
+                    not r.strip().startswith("#")]
+    return requirements
+
+
+with open(path.join(BASE_PATH, "README.md"), "r") as f:
+    long_description = f.read()
+
+with open(path.join(BASE_PATH, "version.py"), "r",
+          encoding="utf-8") as v:
+    for line in v.readlines():
+        if line.startswith("__version__"):
+            if '"' in line:
+                version = line.split('"')[1]
+            else:
+                version = line.split("'")[1]
+
+setup(
+    name='neon-phal-plugin-monitoring',
+    version=version,
+    license='BSD-3',
+    author='Neongecko',
+    author_email='developers@neon.ai',
+    url='https://github.com/NeonGeckoCom/neon-phal-plugin-monitoring',
+    description='Core Monitoring Service',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    install_requires=get_requirements('requirements.txt'),
+    packages=find_packages(),
+    entry_points={'ovos.plugin.phal': PLUGIN_ENTRY_POINT}
+)

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -1,0 +1,66 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+
+from neon_phal_plugin_monitoring import CoreMonitor
+from ovos_utils.messagebus import FakeBus
+
+
+class PluginTests(unittest.TestCase):
+    bus = FakeBus()
+    plugin = CoreMonitor(bus)
+
+    def test_properties(self):
+        # Test default values
+        self.plugin.config['save_locally'] = None
+        self.plugin.config['upload_enabled'] = None
+        self.assertTrue(self.plugin.save_local)
+        self.assertFalse(self.plugin.upload_enabled)
+
+        # Test explicitly enabled
+        self.plugin.config['save_locally'] = True
+        self.plugin.config['upload_enabled'] = True
+        self.assertTrue(self.plugin.save_local)
+        self.assertTrue(self.plugin.upload_enabled)
+
+        # Test explicitly disabled
+        self.plugin.config['save_locally'] = False
+        self.plugin.config['upload_enabled'] = False
+        self.assertFalse(self.plugin.save_local)
+        self.assertFalse(self.plugin.upload_enabled)
+
+        # Test invalid param uses default
+        self.plugin.config['save_locally'] = ""
+        self.plugin.config['upload_enabled'] = ""
+        self.assertTrue(self.plugin.save_local)
+        self.assertFalse(self.plugin.upload_enabled)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit_tests.py
+++ b/tests/unit_tests.py
@@ -27,9 +27,36 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import unittest
+from time import time
+from unittest.mock import Mock
+
+from ovos_bus_client import Message
 
 from neon_phal_plugin_monitoring import CoreMonitor
 from ovos_utils.messagebus import FakeBus
+
+
+_test_metrics = \
+    {"local_interaction": [{"name": "local_interaction",
+                            "timestamp": 1700178575.3139226,
+                            "data": {"timestamps": {"handle_utterance": 1700178569.8474872, "speech_start": 1700178570.3148665, "audio_begin": 1700178572.6613815, "audio_end": 1700178575.1817648},
+                                     "durations": {"save_transcript": 1.6450881958007812e-05, "text_parsers": 0.032979726791381836, "transform_utterance": 0.032979726791381836, "get_tts": 1.4289357662200928}}},
+                           {"name": "local_interaction",
+                            "timestamp": 1700181101.1420398,
+                            "data": {"timestamps": {"handle_utterance": 1700181095.9473078, "speech_start": 1700181096.5109103, "audio_begin": 1700181098.4522712, "audio_end": 1700181100.8959959},
+                                     "durations": {"save_transcript": 8.58306884765625e-06, "text_parsers": 0.03899049758911133, "transform_utterance": 0.03899049758911133, "get_tts": 1.2423529624938965}}},
+                           {"name": "local_interaction",
+                            "timestamp": 1700181115.9253693,
+                            "data": {"timestamps": {"handle_utterance": 1700181107.428496, "speech_start": 1700181109.1827643, "audio_begin": 1700181111.1001081, "audio_end": 1700181115.734644},
+                                     "durations": {"save_transcript": 1.0013580322265625e-05, "text_parsers": 0.03647017478942871, "transform_utterance": 0.03647017478942871, "get_tts": 1.5272321701049805}}},
+                          ],
+     "get_tts": [{"name": "get_tts",
+                  "timestamp": 1700180250.5474644,
+                  "data": {"duration": 1.339482307434082}},
+                 {"name": "get_tts",
+                  "timestamp": 1700180350.5474644,
+                  "data": {"duration": 3.339482307434082}}
+                 ]}
 
 
 class PluginTests(unittest.TestCase):
@@ -60,6 +87,110 @@ class PluginTests(unittest.TestCase):
         self.plugin.config['upload_enabled'] = ""
         self.assertTrue(self.plugin.save_local)
         self.assertFalse(self.plugin.upload_enabled)
+
+        self.assertIsInstance(self.plugin.max_num_history, int)
+
+    def test_init(self):
+        self.assertIsInstance(self.plugin._metrics, dict)
+        for event in ("neon.metric", "neon.get_metric", "neon.get_raw_metric"):
+            self.assertEqual(len(self.plugin.bus.ee.listeners(event)), 1)
+
+    def test_on_metric(self):
+        self.plugin._metrics = {}
+
+        message = Message("neon.metric",
+                          {"name": "test", "time1": time(), "time2": time()})
+        self.plugin.on_metric(message)
+        self.assertEqual(len(self.plugin._metrics['test']), 1)
+        metric = self.plugin._metrics['test'][0]
+        self.assertEqual(metric['name'], 'test')
+        self.assertIsInstance(metric['timestamp'], float)
+        self.assertEqual(set(metric['data'].keys()), {'time1', 'time2'})
+        message.context['timestamp'] = time()
+        self.plugin.on_metric(message)
+        self.assertEqual(len(self.plugin._metrics['test']), 2)
+        metric2 = self.plugin._metrics['test'][1]
+        self.assertNotEqual(metric, metric2)
+        self.assertEqual(metric['name'], metric2['name'])
+        self.assertEqual(metric['data'], metric2['data'])
+        self.assertEqual(metric2['timestamp'], message.context['timestamp'])
+
+    def test_get_raw_metric(self):
+        self.plugin._metrics = {"test": [{"name": "test",
+                                          "timestamp": time(),
+                                          "data": {"value": time()}}],
+                                "test2": [{"name": "test",
+                                           "timestamp": time(),
+                                           "data": {"value": time()}},
+                                          {"name": "test",
+                                           "timestamp": time(),
+                                           "data": {"value": time()}}
+                                          ]}
+        on_raw_metric = Mock()
+        self.bus.on("neon.get_raw_metric.response", on_raw_metric)
+
+        test_all_metrics = Message("neon.get_raw_metric")
+        self.plugin.get_raw_metric(test_all_metrics)
+        resp = on_raw_metric.call_args[0][0]
+        self.assertEqual(resp.data, {**self.plugin._metrics, "error": False})
+
+        test_valid_metric = Message("neon.get_raw_metric", {"name": "test2"})
+        self.plugin.get_raw_metric(test_valid_metric)
+        resp = on_raw_metric.call_args[0][0]
+        self.assertEqual(resp.data, {"test2": self.plugin._metrics['test2'],
+                                     "error": False})
+
+        test_invalid_metric = Message("neon.get_raw_metric", {"name": "test0"})
+        self.plugin.get_raw_metric(test_invalid_metric)
+        resp = on_raw_metric.call_args[0][0]
+        self.assertTrue(resp.data["error"])
+        self.assertTrue(all((x in resp.data['message']
+                             for x in self.plugin._metrics.keys())))
+
+    def test_get_metric(self):
+        self.plugin._metrics = _test_metrics
+        on_metric = Mock()
+        self.bus.on("neon.get_metric.response", on_metric)
+
+        test_simple_metric = Message("neon.get_metric",
+                                     {"name": "get_tts"})
+        self.plugin.get_metric(test_simple_metric)
+        resp = on_metric.call_args[0][0]
+        self.assertFalse(resp.data['error'])
+        self.assertEqual(set(resp.data['duration'].keys()),
+                         {"min", "max", "avg"})
+
+        test_nested_metrics = Message("neon.get_metric",
+                                      {"name": "local_interaction"})
+        self.plugin.get_metric(test_nested_metrics)
+        resp = on_metric.call_args[0][0]
+        self.assertFalse(resp.data['error'])
+        for metric in ("timestamps.handle_utterance", "timestamps.speech_start",
+                       "timestamps.audio_begin", "timestamps.audio_end",
+                       "durations.save_transcript", "durations.text_parsers",
+                       "durations.transform_utterance", "durations.get_tts"):
+            self.assertEqual(set(resp.data[metric].keys()),
+                             {"min", "max", "avg"})
+
+        test_invalid_metric = Message("neon.get_metric", {"name": "test"})
+        self.plugin.get_metric(test_invalid_metric)
+        resp = on_metric.call_args[0][0]
+        self.assertTrue(resp.data['error'])
+        self.assertTrue(all((x in resp.data['message']
+                             for x in self.plugin._metrics.keys())))
+
+        test_missing_metric = Message("neon.get_metric")
+        self.plugin.get_metric(test_missing_metric)
+        resp = on_metric.call_args[0][0]
+        self.assertTrue(resp.data['error'])
+
+    def test_write_to_disk(self):
+        # TODO
+        pass
+
+    def test_shutdown(self):
+        # TODO
+        pass
 
 
 if __name__ == '__main__':

--- a/version.py
+++ b/version.py
@@ -1,0 +1,29 @@
+# NEON AI (TM) SOFTWARE, Software Development Kit & Application Framework
+# All trademark and other rights reserved by their respective owners
+# Copyright 2008-2022 Neongecko.com Inc.
+# Contributors: Daniel McKnight, Guy Daniels, Elon Gasper, Richard Leeds,
+# Regina Bloomstine, Casimiro Ferreira, Andrii Pernatii, Kirill Hrymailo
+# BSD-3 License
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS  BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+# OR PROFITS;  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+__version__ = "0.0.1a1"


### PR DESCRIPTION
# Description
Initial implementation with support for adding and querying metrics via the messagebus
By default metrics are saved to disk but not reported via MQ to a backend
By default, up to 100 entries per metric are saved/used in calculations

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
- [x] Needs PyPI token permissions before merge